### PR TITLE
Fix code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -102,7 +102,10 @@ export class FileController extends BaseController {
   ) {
     try {
       // Sanitize the path to prevent directory traversal
-      const sanitizedPath = path.replace(/\.\.\//g, '');
+      let sanitizedPath = path;
+      while (sanitizedPath.includes('../')) {
+        sanitizedPath = sanitizedPath.replace(/\.\.\//g, '');
+      }
       const filePath = join(
         process.cwd(),
         UPLOAD_LOCATION || '',


### PR DESCRIPTION
Fixes [https://github.com/llong2195/nest-fastify-drizzle/security/code-scanning/6](https://github.com/llong2195/nest-fastify-drizzle/security/code-scanning/6)

To fix the problem, we need to ensure that all instances of `../` are removed from the path, not just the first occurrence. One effective way to achieve this is to repeatedly apply the regular expression replacement until no more replacements can be performed. This ensures that all instances of the targeted pattern are removed.

We will modify the code to repeatedly replace `../` in the path until the path no longer changes. This will be done by using a loop that continues to apply the replacement until the path remains the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
